### PR TITLE
Allow skipping storage formatting (persistent mode)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.14 AS builder
-ENV KAFKA_VERSION=3.0.0
+ENV KAFKA_VERSION=3.1.1
 ENV SCALA_VERSION=2.13
 COPY install_kafka.sh /bin/
 RUN apk update \

--- a/start_kafka.sh
+++ b/start_kafka.sh
@@ -28,6 +28,9 @@ else
   sed -r -i "s@^#?inter.broker.listener.name=.*@inter.broker.listener.name=$KAFKA_INTER_BROKER_LISTENER_NAME@g" "/opt/kafka/config/kraft/server.properties"
 fi
 
-uuid=$(/opt/kafka/bin/kafka-storage.sh random-uuid)
-/opt/kafka/bin/kafka-storage.sh format -t $uuid -c /opt/kafka/config/kraft/server.properties
+if [[ -z "$KAFKA_SKIP_STORAGE_FORMAT" ]]; then
+  uuid=$(/opt/kafka/bin/kafka-storage.sh random-uuid)
+  /opt/kafka/bin/kafka-storage.sh format -t $uuid -c /opt/kafka/config/kraft/server.properties
+fi
+
 /opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/kraft/server.properties

--- a/start_kafka.sh
+++ b/start_kafka.sh
@@ -28,7 +28,8 @@ else
   sed -r -i "s@^#?inter.broker.listener.name=.*@inter.broker.listener.name=$KAFKA_INTER_BROKER_LISTENER_NAME@g" "/opt/kafka/config/kraft/server.properties"
 fi
 
-if [[ -z "$KAFKA_SKIP_STORAGE_FORMAT" ]]; then
+if [ ! -f /tmp/kraft-combined-logs/meta.properties ]; then
+  echo 'Preparing storage directory'
   uuid=$(/opt/kafka/bin/kafka-storage.sh random-uuid)
   /opt/kafka/bin/kafka-storage.sh format -t $uuid -c /opt/kafka/config/kraft/server.properties
 fi


### PR DESCRIPTION
The use case is mounted volumes to keep data between container restarts.

I tested it with these commands
```shell
# creating shared volume
docker volume create dev-kafka-vl

# first run
# will print this to output: Formatting /tmp/kraft-combined-logs
docker run --rm --name dev-kafka -v dev-kafka-vl:/tmp/kraft-combined-logs -p 9092:9092 -it custom-kafka-craft

# second run after the first container is destroyed
# no message about formatting printed
docker run --rm --name dev-kafka -e KAFKA_SKIP_STORAGE_FORMAT=true -v dev-kafka-vl:/tmp/kraft-combined-logs -p 9092:9092 -it custom-kafka-craft
```

`custom-kafka-craft` - image name built from this branch locally